### PR TITLE
spi2ahb (AHB master) -> spictrl (APB slave)

### DIFF
--- a/altera/make_prj.tcl
+++ b/altera/make_prj.tcl
@@ -30,14 +30,19 @@ set GAISLER_SET {
     ../../grlib/lib/gaisler/uart/ahbuart.vhd
     ../../grlib/lib/gaisler/uart/apbuart.vhd
     ../../grlib/lib/gaisler/spi/spi.vhd
-    ../../grlib/lib/gaisler/spi/spi2ahb.vhd
-    ../../grlib/lib/gaisler/spi/spi2ahbx.vhd
+    ../../grlib/lib/gaisler/spi/spictrlx.vhd
+    ../../grlib/lib/gaisler/spi/spictrl.vhd
     ../../grlib/lib/gaisler/leon3/leon3.vhd
     ../../grlib/lib/gaisler/irqmp/irqmp.vhd
 }
 
 set TECHMAP_SET {
+    ../../grlib/lib/techmap/gencomp/netcomp.vhd
     ../../grlib/lib/techmap/gencomp/gencomp.vhd
+    ../../grlib/lib/techmap/inferred/memory_inferred.vhd
+    ../../grlib/lib/techmap/alltech/allmem.vhd
+    ../../grlib/lib/techmap/maps/memrwcol.vhd
+    ../../grlib/lib/techmap/maps/syncram_2p.vhd
 }
 
 foreach vhdl_file $GRLIB_SET {


### PR DESCRIPTION
Change spi core from spi2ahb to spictrl, because here we need only
translate SPI signals to bus and spictrl is enough.

Also delete IRQ ctrl, because it has no use in the project.